### PR TITLE
Fix validation bug caused by body not being rewound

### DIFF
--- a/lib/ralyxa/request_entities/request.rb
+++ b/lib/ralyxa/request_entities/request.rb
@@ -15,6 +15,7 @@ module Ralyxa
 
       def initialize(original_request, user_class = Ralyxa::RequestEntities::User)
         @request = JSON.parse(original_request.body.read)
+        original_request.body.rewind
         @user = user_class.build(@request)
 
         validate_request(original_request) if Ralyxa.configuration.validate_requests?

--- a/spec/ralyxa/request_entities/request_spec.rb
+++ b/spec/ralyxa/request_entities/request_spec.rb
@@ -3,7 +3,7 @@ require 'ralyxa/request_entities/request'
 RSpec.describe Ralyxa::RequestEntities::Request, vcr: true do
   describe '#intent_name' do
     it 'returns the IntentName from the request' do
-      stubbed_request = stub_sinatra_request({  
+      stubbed_request = stub_sinatra_request({
         "request": {
           "type": "IntentRequest",
           "intent": {
@@ -22,7 +22,7 @@ RSpec.describe Ralyxa::RequestEntities::Request, vcr: true do
     end
 
     it 'returns the IntentName if the request is a built-in request' do
-      stubbed_request = stub_sinatra_request({  
+      stubbed_request = stub_sinatra_request({
         "request": {
           "type": "LaunchRequest"
         }
@@ -129,7 +129,7 @@ RSpec.describe Ralyxa::RequestEntities::Request, vcr: true do
         described_class.new(stubbed_request, user_class).user_access_token_exists?
       end
     end
-  
+
   end
 
   describe 'request verification' do
@@ -147,11 +147,11 @@ RSpec.describe Ralyxa::RequestEntities::Request, vcr: true do
     end
 
     let(:valid_env) { { "HTTP_SIGNATURECERTCHAINURL" => 'https://s3.amazonaws.com/echo.api/echo-api-cert-5.pem', "HTTP_SIGNATURE" => "jJsLfPdMlcILlbOpGR2PLbJyb+CJrsAHgATg34UB5zyCYkHqRJvNDlJmxHar76B10Bk7UFJOWue4Fo772W0/cVJREK3HdqLnUNvJ9Yn2gs9ZLZQKQHFDysvo+0bKXA60Fi7RyF/O21m5i/u+LJlhNs3pkiOSUgXUmbST2cECpkG5yZWch7sgl8EEjk94FUy1s7gfCdT2Y4f4UGafQ5CJNtuEXCCaw0uu9NOY/RGBY1Gv+COmTlppvFLtFNqRbl9tJ7nSF44fcSIEPdJHoVDQ7FxdsbZopoZbsApNTHXXQun3+HuPYZG2kwiZ5Bt2z5F8WhbsdaplAB6CUltHVRsngQ==" } }
-    let(:valid_body) { double(:body, read: " {\"session\": \n{\"sessionId\":\"SessionId.1cfa16c1-9794-4e44-9358-a009f0a6ea1c\",\"application\":{\"applicationId\":\"amzn1.ask.skill.f5e6173c-8f7a-4c51-85e8-275e52d9443b\"},\"attributes\":{},\"user\":{\"userId\":\"amzn1.ask.account.AFLKBJN4MUE2INQZPMXA2EQFB7ABENF646BL4526SWH7DQNKBVANCPKU4SMWN7ZJEOWIN3RSTZ3L2IJBDGBICRWVBADLN62UB6HNWA4VK2MCZD3DCNOZ6USQDZZSQFD2GRKUC4V5YWPYXJFILKLVEA7IJB2MY4ILWEJ3TC6MG7VQVFHK7PE6VH5KT2QUPWH4KPYOT6EY4DDWEBY\",\"accessToken\":null},\"new\":true},\n\"request\":\n{\"intent\":{\"name\":\"PlayAudio\",\"slots\":{}},\"requestId\":\"EdwRequestId.edb164fe-5dd1-4fb1-984b-bba5f0d2ee6d\",\"type\":\"IntentRequest\",\"locale\":\"en-GB\",\"timestamp\":\"2017-11-20T08:45:02Z\"},\"context\":{\"AudioPlayer\":{\"playerActivity\":\"IDLE\"},\"System\":{\"application\":{\"applicationId\":\"amzn1.ask.skill.f5e6173c-8f7a-4c51-85e8-275e52d9443b\"},\"user\":{\"userId\":\"amzn1.ask.account.AFLKBJN4MUE2INQZPMXA2EQFB7ABENF646BL4526SWH7DQNKBVANCPKU4SMWN7ZJEOWIN3RSTZ3L2IJBDGBICRWVBADLN62UB6HNWA4VK2MCZD3DCNOZ6USQDZZSQFD2GRKUC4V5YWPYXJFILKLVEA7IJB2MY4ILWEJ3TC6MG7VQVFHK7PE6VH5KT2QUPWH4KPYOT6EY4DDWEBY\"},\"device\":{\"supportedInterfaces\":{}}}},\"version\":\"1.0\"}", rewind: nil) }
+    let(:valid_body) { StringIO.new(" {\"session\": \n{\"sessionId\":\"SessionId.1cfa16c1-9794-4e44-9358-a009f0a6ea1c\",\"application\":{\"applicationId\":\"amzn1.ask.skill.f5e6173c-8f7a-4c51-85e8-275e52d9443b\"},\"attributes\":{},\"user\":{\"userId\":\"amzn1.ask.account.AFLKBJN4MUE2INQZPMXA2EQFB7ABENF646BL4526SWH7DQNKBVANCPKU4SMWN7ZJEOWIN3RSTZ3L2IJBDGBICRWVBADLN62UB6HNWA4VK2MCZD3DCNOZ6USQDZZSQFD2GRKUC4V5YWPYXJFILKLVEA7IJB2MY4ILWEJ3TC6MG7VQVFHK7PE6VH5KT2QUPWH4KPYOT6EY4DDWEBY\",\"accessToken\":null},\"new\":true},\n\"request\":\n{\"intent\":{\"name\":\"PlayAudio\",\"slots\":{}},\"requestId\":\"EdwRequestId.edb164fe-5dd1-4fb1-984b-bba5f0d2ee6d\",\"type\":\"IntentRequest\",\"locale\":\"en-GB\",\"timestamp\":\"2017-11-20T08:45:02Z\"},\"context\":{\"AudioPlayer\":{\"playerActivity\":\"IDLE\"},\"System\":{\"application\":{\"applicationId\":\"amzn1.ask.skill.f5e6173c-8f7a-4c51-85e8-275e52d9443b\"},\"user\":{\"userId\":\"amzn1.ask.account.AFLKBJN4MUE2INQZPMXA2EQFB7ABENF646BL4526SWH7DQNKBVANCPKU4SMWN7ZJEOWIN3RSTZ3L2IJBDGBICRWVBADLN62UB6HNWA4VK2MCZD3DCNOZ6USQDZZSQFD2GRKUC4V5YWPYXJFILKLVEA7IJB2MY4ILWEJ3TC6MG7VQVFHK7PE6VH5KT2QUPWH4KPYOT6EY4DDWEBY\"},\"device\":{\"supportedInterfaces\":{}}}},\"version\":\"1.0\"}") }
     let(:valid_request) { double(:request, env: valid_env, body: valid_body) }
 
     let(:invalid_env) { { "HTTP_SIGNATURECERTCHAINURL" => 'http://bad.example', "HTTP_SIGNATURE" => 'invalid' } }
-    let(:invalid_body) { double(:body, read: '{ "invalid": true }', rewind: nil) }
+    let(:invalid_body) { StringIO.new('{ "invalid": true }') }
     let(:invalid_request) { double(:request, env: invalid_env, body: invalid_body) }
 
     it 'verifies valid requests' do


### PR DESCRIPTION
The validation code inside the AlexaVerifier gem also uses `request.body.read` as a result the tests stubbing is hiding the error. 

Using StringIO is a better test case here and ensures we do the required rewind.