### PR TITLE
Add support for AudioPlayer directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Gemfile.lock
+coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
 Metrics/LineLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  Max: 6
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,55 @@ intent "ReadFromSession" do
 end
 ```
 
+##### Playing audio with the `AudioPlayer` directive
+
+###### Play
+
+You can play an audio stream right away with:
+
+```ruby
+intent "PlayAudio" do
+  audio_player.play(
+    'https://s3.amazonaws.com/my-ssml-samples/Flourish.mp3',
+    'flourish-token',
+    speech: 'Playing Audio'
+  )
+end
+```
+
+###### Play Later (Enqueue)
+
+You can queue a song to play next with:
+
+```ruby
+intent "PlayAudioLater" do
+  audio_player.play_later(
+    'https://s3.amazonaws.com/my-ssml-samples/Flourish.mp3',
+    'flourish-token'
+  )
+end
+```
+
+###### Stop
+
+You can stop playing with:
+
+```ruby
+intent "StopAudio" do
+  audio_player.stop
+end
+```
+
+###### Clear Queued
+
+You can clear enqueued audio with:
+
+```ruby
+intent "ClearQueue" do
+  audio_player.clear_queue
+end
+```
+
 ##### Reading the session user
 
 You can read the session user's `userId` and `accessToken`, and check that the `accessToken` exists:
@@ -148,7 +197,8 @@ end
 
 # Standard card
 intent "SendStandardCard" do
-  standard_card = card("Hello World", "I'm alive!", "https://placehold.it/200")
+  standard_card = card("Hello World", "I'm alive!", "http://placehold.it/720x480", "http://placehold.it/1200x800")
+  
   ask("What do you think of the Standard card I just sent?", card: standard_card)
 end
 ```
@@ -190,6 +240,20 @@ end
 
 > You can't actually respond to a `SessionEndedRequest`, but you might want to do some tidying in this action.
 
+
+### I want to serve card images, audio stream etc. over HTTP not HTTPS
+
+In some special cases, you may be allowed to serve content over HTTP instead of HTTPS. To allow this within Ralyxa, you need to set the `require_secure_urls` configuration option to false.
+
+> **NOTE:** In order to use HTTP sources, you must be given special approval directly from Amazon. If you use HTTP sources without getting advanced approval, your skill will not work correctly.
+
+```ruby
+Ralyxa.configure do |config|
+  config.require_secure_urls = false
+end
+```
+
+
 ## Testing
 Part of Amazon's requirements for Alexa skills is that they have to ensure requests are sent from Amazon. This is done in a number of ways documented [here](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-a-web-service.html). This verification is built into Ralyxa and can cause issues when testing your skills with stubbed data.
 
@@ -219,9 +283,10 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/sjmog/
 
 The main areas of focus are:
 
-- Audio directives :construction:
 - Reprompts :construction:
+- Dialogue :construction:
 - Generators of built-in Intents e.g. `SessionEndedRequest`
+- Automation with the `AVS` command line tool
 
 ## License
 

--- a/lib/ralyxa/configuration.rb
+++ b/lib/ralyxa/configuration.rb
@@ -1,13 +1,18 @@
 module Ralyxa
   class Configuration
-    attr_accessor :validate_requests
+    attr_accessor :validate_requests, :require_secure_urls
 
     def initialize
       @validate_requests = true
+      @require_secure_urls = true
     end
 
     def validate_requests?
       validate_requests
+    end
+
+    def require_secure_urls?
+      require_secure_urls
     end
   end
 end

--- a/lib/ralyxa/errors.rb
+++ b/lib/ralyxa/errors.rb
@@ -1,2 +1,4 @@
-class UnsecureUrlError < StandardError
+module Ralyxa
+  class UnsecureUrlError < StandardError
+  end
 end

--- a/lib/ralyxa/handler.rb
+++ b/lib/ralyxa/handler.rb
@@ -13,7 +13,10 @@ module Ralyxa
     end
 
     def respond(response_text = '', response_details = {}, response_builder = Ralyxa::ResponseBuilder)
-      response_builder.build(response_details.merge(response_text: response_text))
+      options = response_details
+      options[:response_text] = response_text if response_text
+
+      response_builder.build(options)
     end
 
     def tell(response_text = '', response_details = {})
@@ -24,8 +27,16 @@ module Ralyxa
       card_class.as_hash(title, body, image_url)
     end
 
+    def audio_player
+      Ralyxa::ResponseEntities::Directives::AudioPlayer
+    end
+
     def link_account_card(card_class = Ralyxa::ResponseEntities::Card)
       card_class.link_account
+    end
+
+    def log(level, message)
+      puts "[#{Time.new}] [#{@request.user_id}] #{level} - #{message}"
     end
 
     alias ask respond

--- a/lib/ralyxa/request_entities/request.rb
+++ b/lib/ralyxa/request_entities/request.rb
@@ -13,13 +13,15 @@ module Ralyxa
       def_delegator :@user, :access_token, :user_access_token
       def_delegator :@user, :access_token_exists?, :user_access_token_exists?
 
+      attr_reader :request
+
       def initialize(original_request, user_class = Ralyxa::RequestEntities::User)
+        validate_request(original_request) if Ralyxa.configuration.validate_requests?
+
         @request = JSON.parse(original_request.body.read)
         attempt_to_rewind_request_body(original_request)
 
         @user = user_class.build(@request)
-
-        validate_request(original_request) if Ralyxa.configuration.validate_requests?
       end
 
       def intent_name
@@ -35,8 +37,12 @@ module Ralyxa
         @request['session']['new']
       end
 
+      def session_attributes
+        @request['session']['attributes']
+      end
+
       def session_attribute(attribute_name)
-        @request['session']['attributes'][attribute_name]
+        session_attributes[attribute_name]
       end
 
       private

--- a/lib/ralyxa/request_entities/user.rb
+++ b/lib/ralyxa/request_entities/user.rb
@@ -9,9 +9,11 @@ module Ralyxa
       end
 
       def self.build(request)
+        user_hash = request.dig('session', 'user') || request.dig('context', 'System', 'user') || {}
+
         new(
-          id: request.dig('session', 'user', 'userId'),
-          access_token: request.dig('session', 'user', 'accessToken')
+          id: user_hash['userId'],
+          access_token: user_hash['accessToken']
         )
       end
 

--- a/lib/ralyxa/response_builder.rb
+++ b/lib/ralyxa/response_builder.rb
@@ -14,7 +14,7 @@ module Ralyxa
     end
 
     def build
-      merge_output_speech
+      merge_output_speech if response_text_exists?
       merge_card if card_exists?
 
       @response_class.as_hash(@options).to_json
@@ -32,6 +32,10 @@ module Ralyxa
 
     def card_exists?
       @options[:card]
+    end
+
+    def response_text_exists?
+      @options[:response_text]
     end
 
     def output_speech

--- a/lib/ralyxa/response_entities/directives.rb
+++ b/lib/ralyxa/response_entities/directives.rb
@@ -1,0 +1,9 @@
+require_relative './directives/audio'
+require_relative './directives/audio_player'
+
+module Ralyxa
+  module ResponseEntities
+    module Directives
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio.rb
+++ b/lib/ralyxa/response_entities/directives/audio.rb
@@ -1,0 +1,11 @@
+require_relative './audio/audio_item'
+require_relative './audio/stream'
+
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      module Audio
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio/audio_item.rb
+++ b/lib/ralyxa/response_entities/directives/audio/audio_item.rb
@@ -1,0 +1,23 @@
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      module Audio
+        class AudioItem
+          def initialize(stream)
+            @stream = stream
+          end
+
+          def to_h
+            {}.tap do |audio_item|
+              audio_item['stream'] = @stream.to_h
+            end
+          end
+
+          def self.as_hash(stream)
+            new(stream).to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio/stream.rb
+++ b/lib/ralyxa/response_entities/directives/audio/stream.rb
@@ -1,0 +1,37 @@
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      module Audio
+        class Stream
+          def initialize(url, token, offset_in_milliseconds = 0, expected_previous_token = nil)
+            raise Ralyxa::UnsecureUrlError, "Audio streams must be served from at an SSL-enabled (HTTPS) endpoint. Your current stream url is: #{url}" unless secure?(url)
+
+            @url                     = url
+            @token                   = token
+            @offset_in_milliseconds  = offset_in_milliseconds
+            @expected_previous_token = expected_previous_token
+          end
+
+          def to_h
+            {}.tap do |stream|
+              stream['url']                   = @url
+              stream['token']                 = @token
+              stream['offsetInMilliseconds']  = @offset_in_milliseconds
+              stream['expectedPreviousToken'] = @expected_previous_token if @expected_previous_token
+            end
+          end
+
+          def self.as_hash(url, token, offset_in_milliseconds = 0, expected_previous_token = nil)
+            new(url, token, offset_in_milliseconds, expected_previous_token).to_h
+          end
+
+          private
+
+          def secure?(url)
+            URI.parse(url).scheme == 'https' || !Ralyxa.require_secure_urls?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio_player.rb
+++ b/lib/ralyxa/response_entities/directives/audio_player.rb
@@ -1,0 +1,46 @@
+require_relative './audio_player/clear_queue'
+require_relative './audio_player/play'
+require_relative './audio_player/stop'
+
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      class AudioPlayer
+        class << self
+          def play(url, token, speech: nil, card: nil, offset_in_milliseconds: 0, expected_previous_token: nil, behaviour: Ralyxa::ResponseEntities::Directives::AudioPlayer::Play::REPLACE_ALL, audio_player_class: Ralyxa::ResponseEntities::Directives::AudioPlayer::Play, response_builder: Ralyxa::ResponseBuilder)
+            directive = audio_player_class.as_hash(Ralyxa::ResponseEntities::Directives::Audio::Stream.new(url, token, offset_in_milliseconds, expected_previous_token), behaviour)
+
+            response_builder.build(build_options(directive, speech, card))
+          end
+
+          def play_later(url, token, speech: nil, card: nil, offset_in_milliseconds: 0, expected_previous_token: nil, behaviour: Ralyxa::ResponseEntities::Directives::AudioPlayer::Play::REPLACE_ENQUEUED, audio_player_class: Ralyxa::ResponseEntities::Directives::AudioPlayer::Play, response_builder: Ralyxa::ResponseBuilder)
+            play(url, token, speech: speech, card: card, offset_in_milliseconds: offset_in_milliseconds, expected_previous_token: expected_previous_token, behaviour: behaviour, audio_player_class: audio_player_class, response_builder: response_builder)
+          end
+
+          def stop(speech: nil, card: nil, audio_player_class: Ralyxa::ResponseEntities::Directives::AudioPlayer::Stop, response_builder: Ralyxa::ResponseBuilder)
+            directive = audio_player_class.as_hash
+
+            response_builder.build(build_options(directive, speech, card))
+          end
+
+          def clear_queue(speech: nil, card: nil, behaviour: Ralyxa::ResponseEntities::Directives::AudioPlayer::ClearQueue::CLEAR_ALL, audio_player_class: Ralyxa::ResponseEntities::Directives::AudioPlayer::ClearQueue, response_builder: Ralyxa::ResponseBuilder)
+            directive = audio_player_class.as_hash(behaviour)
+
+            response_builder.build(build_options(directive, speech, card))
+          end
+
+          private
+
+          def build_options(directive, speech, card)
+            {}.tap do |option|
+              option[:directives] = [directive]
+              option[:end_session] = false
+              option[:response_text] = speech if speech
+              option[:card] = card if card
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio_player/clear_queue.rb
+++ b/lib/ralyxa/response_entities/directives/audio_player/clear_queue.rb
@@ -1,0 +1,27 @@
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      class AudioPlayer
+        class ClearQueue
+          CLEAR_ENQUEUED = 'CLEAR_ENQUEUED'.freeze
+          CLEAR_ALL = 'CLEAR_ALL'.freeze
+
+          def initialize(behaviour = Ralyxa::ResponseEntities::Directives::AudioPlayer::ClearQueue::CLEAR_ENQUEUED)
+            @behaviour = behaviour
+          end
+
+          def to_h
+            {}.tap do |audio_player|
+              audio_player['type'] = 'AudioPlayer.ClearQueue'
+              audio_player['clearBehavior'] = @behaviour
+            end
+          end
+
+          def self.as_hash(behaviour = Ralyxa::ResponseEntities::Directives::AudioPlayer::ClearQueue::CLEAR_ENQUEUED)
+            new(behaviour).to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio_player/play.rb
+++ b/lib/ralyxa/response_entities/directives/audio_player/play.rb
@@ -1,0 +1,32 @@
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      class AudioPlayer
+        class Play
+          CLEAR_ENQUEUE    = 'CLEAR_ENQUEUE'.freeze
+          ENQUEUE          = 'ENQUEUE'.freeze
+          REPLACE_ALL      = 'REPLACE_ALL'.freeze
+          REPLACE_ENQUEUED = 'REPLACE_ENQUEUED'.freeze
+
+          def initialize(stream, behaviour = Ralyxa::ResponseEntities::Directives::AudioPlayer::Play::REPLACE_ALL)
+            @stream    = stream
+            @behaviour = behaviour
+          end
+
+          def to_h
+            {}.tap do |audio_player|
+              audio_player['type'] = 'AudioPlayer.Play'
+              audio_player['playBehavior'] = @behaviour
+
+              audio_player['audioItem'] = Ralyxa::ResponseEntities::Directives::Audio::AudioItem.new(@stream).to_h
+            end
+          end
+
+          def self.as_hash(stream, behaviour = nil)
+            new(stream, behaviour).to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/directives/audio_player/stop.rb
+++ b/lib/ralyxa/response_entities/directives/audio_player/stop.rb
@@ -1,0 +1,19 @@
+module Ralyxa
+  module ResponseEntities
+    module Directives
+      class AudioPlayer
+        class Stop
+          def to_h
+            {}.tap do |audio_player|
+              audio_player['type'] = 'AudioPlayer.Stop'
+            end
+          end
+
+          def self.as_hash
+            new.to_h
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/response.rb
+++ b/lib/ralyxa/response_entities/response.rb
@@ -1,14 +1,16 @@
 require_relative './output_speech'
+require_relative './directives'
 
 module Ralyxa
   module ResponseEntities
     class Response
-      def initialize(output_speech, session_attributes, end_session, start_over, card)
+      def initialize(output_speech, session_attributes, end_session, start_over, card, directives)
         @output_speech      = output_speech
         @session_attributes = session_attributes
         @end_session        = end_session
         @start_over         = start_over
         @card               = card
+        @directives         = directives
       end
 
       def to_h
@@ -19,8 +21,8 @@ module Ralyxa
         end
       end
 
-      def self.as_hash(output_speech: Ralyxa::OutputSpeech.as_hash, session_attributes: {}, end_session: false, start_over: false, card: false)
-        new(output_speech, session_attributes, end_session, start_over, card).to_h
+      def self.as_hash(output_speech: false, session_attributes: {}, end_session: false, start_over: false, card: false, directives: false)
+        new(output_speech, session_attributes, end_session, start_over, card, directives).to_h
       end
 
       private
@@ -37,10 +39,12 @@ module Ralyxa
       end
 
       def add_response(response)
-        response[:response] = {}
-        response[:response][:outputSpeech] = @output_speech
-        response[:response][:card] = @card if @card
-        response[:response][:shouldEndSession] = @end_session
+        response[:response] = {}.tap do |response_object|
+          response_object[:outputSpeech]     = @output_speech if @output_speech
+          response_object[:card]             = @card          if @card
+          response_object[:directives]       = @directives    if @directives
+          response_object[:shouldEndSession] = @end_session
+        end
       end
     end
   end

--- a/ralyxa.gemspec
+++ b/ralyxa.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'vcr',     '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
+  spec.add_development_dependency 'simplecov', '~> 0.15'
 end

--- a/spec/ralyxa/configuration_spec.rb
+++ b/spec/ralyxa/configuration_spec.rb
@@ -6,19 +6,15 @@ RSpec.describe Ralyxa::Configuration do
   describe '#initialize' do
     it 'sets default configuration values' do
       expect(ralyxa_configuration.validate_requests).to eq(true)
+      expect(ralyxa_configuration.require_secure_urls).to eq(true)
     end
   end
 
   describe '#validate_requests?' do
-    it 'returns the value of validate_request' do
-      configuration = ralyxa_configuration
-      expect(configuration.validate_requests?).to eq(true)
+    it_should_behave_like 'a configuration option', :validate_requests
+  end
 
-      configuration.validate_requests = false
-      expect(configuration.validate_requests?).to eq(false)
-
-      configuration.validate_requests = 'foo'
-      expect(configuration.validate_requests?).to eq('foo')
-    end
+  describe '#require_secure_urls?' do
+    it_should_behave_like 'a configuration option', :require_secure_urls
   end
 end

--- a/spec/ralyxa/handler_spec.rb
+++ b/spec/ralyxa/handler_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Ralyxa::Handler do
 
         expect(response_builder).to receive(:build).with(response_text: "Hello World")
 
-        handler.send(:respond, "Hello World", {}, response_builder)
+        handler.send(:respond, 'Hello World', {}, response_builder)
       end
     end
 
@@ -47,6 +47,12 @@ RSpec.describe Ralyxa::Handler do
       end
     end
 
+    describe '#audio_player' do
+      it 'creates a new instance of Ralyxa::ResponseEndities::Directives::AudioPlayer' do
+        expect(handler.audio_player).to eq(Ralyxa::ResponseEntities::Directives::AudioPlayer)
+      end
+    end
+
     describe '#link_account_card' do
       it 'constructs an Account Linking card' do
         card_class = double(:"Ralyxa::Card")
@@ -54,6 +60,25 @@ RSpec.describe Ralyxa::Handler do
         expect(card_class).to receive(:link_account)
 
         handler.send(:link_account_card, card_class)
+      end
+    end
+
+    describe '#log' do
+      before :each do
+        Timecop.freeze(Time.local(2017, 01, 28, 00, 16, 04))
+
+        @handler = handler
+        @handler.instance_variable_set(:@request, double(:request, user_id: 'user-1'))
+      end
+
+      after :each do
+        Timecop.return
+      end
+
+      it 'passes the expected information to puts' do
+        expect(STDOUT).to receive(:puts).with('[2017-01-28 00:16:04 +0000] [user-1] TEST - This is a test message')
+
+        handler.send(:log, 'TEST', 'This is a test message')
       end
     end
   end

--- a/spec/ralyxa/response_builder_spec.rb
+++ b/spec/ralyxa/response_builder_spec.rb
@@ -28,16 +28,26 @@ RSpec.describe Ralyxa::ResponseBuilder do
       Ralyxa::ResponseBuilder.build({ card: card }, response_class, output_speech_class)
     end
 
-    it 'plugs the OutputSpeech hash into the Response' do
-      expect(response_class).to receive(:as_hash).with(output_speech: output_speech)
+    context 'with a response_text value' do
+      it 'plugs the OutputSpeech hash into the Response ' do
+        expect(response_class).to receive(:as_hash).with(output_speech: output_speech)
 
-      Ralyxa::ResponseBuilder.build({}, response_class, output_speech_class)
+        Ralyxa::ResponseBuilder.build({response_text: ''}, response_class, output_speech_class)
+      end
+    end
+
+    context 'without a response_text value' do
+      it 'returns an empty hash' do
+        expect(response_class).to receive(:as_hash).with({})
+
+        Ralyxa::ResponseBuilder.build({}, response_class, output_speech_class)
+      end
     end
 
     it 'plugs a Card hash into the Response' do
       card = double(:alexa_card, to_h: {})
 
-      expect(response_class).to receive(:as_hash).with(output_speech: output_speech, card: card.to_h)
+      expect(response_class).to receive(:as_hash).with(card: card.to_h)
 
       Ralyxa::ResponseBuilder.build({ card: card }, response_class, output_speech_class)
     end

--- a/spec/ralyxa/response_entities/card_spec.rb
+++ b/spec/ralyxa/response_entities/card_spec.rb
@@ -15,23 +15,57 @@ RSpec.describe Ralyxa::ResponseEntities::Card do
       expect(simple_card).to eq expected_result
     end
 
-    it 'generates a Standard card given title, body, and an image URL' do
+    it 'generates a Standard card given title, body, and an image hash' do
       expected_result = {
         type: "Standard", 
         title: "Hello Card", 
         text: "Hello, string!", 
         image: { 
-          smallImageUrl: "https://example.com/image.jpg",
-          largeImageUrl: "https://example.com/image.jpg"
+          smallImageUrl: "https://image.url",
+          largeImageUrl: "https://large.image.url"
         }
       }
 
-      standard_card = described_class.as_hash("Hello Card", "Hello, string!", "https://example.com/image.jpg")
+      standard_card = described_class.as_hash("Hello Card", "Hello, string!", "https://image.url", "https://large.image.url")
       expect(standard_card).to eq expected_result
     end
 
     it 'raises an error if the card is given an image that does not start with https://' do
-      expect { described_class.as_hash("Hello Card", "Hello, string!", "http://image.url") }.to raise_error UnsecureUrlError
+      Ralyxa.require_secure_urls = true
+
+      expect { described_class.as_hash("Hello Card", "Hello, string!", "http://image.url", "http://large.image.url") }.to raise_error Ralyxa::UnsecureUrlError
+    end
+
+    context 'with an incomplete image hash' do
+      it 'generates the expected standard card with a small and large image based on the small image' do
+        expected_result = {
+            type: "Standard",
+            title: "Hello Card",
+            text: "Hello, string!",
+            image: {
+                smallImageUrl: "https://image.url",
+                largeImageUrl: "https://image.url"
+            }
+        }
+
+        standard_card = described_class.as_hash("Hello Card", "Hello, string!", "https://image.url")
+        expect(standard_card).to eq expected_result
+      end
+
+      it 'generates the expected standard card with a small and large image based on the large image' do
+        expected_result = {
+            type: "Standard",
+            title: "Hello Card",
+            text: "Hello, string!",
+            image: {
+                smallImageUrl: "https://large.image.url",
+                largeImageUrl: "https://large.image.url"
+            }
+        }
+
+        standard_card = described_class.as_hash("Hello Card", "Hello, string!", nil, "https://large.image.url")
+        expect(standard_card).to eq expected_result
+      end
     end
   end
 

--- a/spec/ralyxa/response_entities/directives/audio/audio_item_spec.rb
+++ b/spec/ralyxa/response_entities/directives/audio/audio_item_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../../../spec_helper'
+
+RSpec.describe Ralyxa::ResponseEntities::Directives::Audio::AudioItem do
+  subject(:audio_item) { described_class.new(Ralyxa::ResponseEntities::Directives::Audio::Stream.new('http://localhost', 'token')) }
+
+  describe '#to_h' do
+    it 'generates the expected hash' do
+      expect(audio_item.to_h).to eq({ "stream" => { "url" => "http://localhost", "token" => "token", "offsetInMilliseconds" => 0 } })
+    end
+  end
+
+  describe '.as_hash' do
+    it 'generates the expected hash' do
+      expect(
+        described_class.as_hash(
+          Ralyxa::ResponseEntities::Directives::Audio::Stream.new(
+            'http://localhost',
+            'token')
+        )
+      ).to eq({ "stream" => { "url" => "http://localhost", "token" => "token", "offsetInMilliseconds" => 0 } })
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/directives/audio/stream_spec.rb
+++ b/spec/ralyxa/response_entities/directives/audio/stream_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../../../../spec_helper'
+
+RSpec.describe Ralyxa::ResponseEntities::Directives::Audio::Stream do
+  describe '#initialize' do
+    it 'raises a Ralyxa::UnsecureUrlError if the url is not served over HTTPS and Ralyxa is configured to use secure URLs only' do
+      Ralyxa.require_secure_urls = true
+
+      expect{ described_class.new('http://localhost', 'token') }.to raise_error(Ralyxa::UnsecureUrlError, 'Audio streams must be served from at an SSL-enabled (HTTPS) endpoint. Your current stream url is: http://localhost')
+    end
+  end
+
+  describe '#to_h' do
+    context 'with expected_previous_token' do
+      subject(:stream) { described_class.new('http://localhost', 'my-token', 100, 'my-previous-token') }
+
+      it 'generates the expected hash' do
+        expect(stream.to_h).to eq({ "url" => "http://localhost", "token" => "my-token", "offsetInMilliseconds" => 100, "expectedPreviousToken" => "my-previous-token" })
+      end
+    end
+
+    context 'without expected_previous_token' do
+      subject(:stream) { described_class.new('http://localhost', 'my-token', 100) }
+
+      it 'generates the expected hash' do
+        expect(stream.to_h).to eq({ "url" => "http://localhost", "token" => "my-token", "offsetInMilliseconds" => 100 })
+      end
+    end
+  end
+
+  describe '.as_hash' do
+    context 'with expected_previous_token' do
+      subject(:stream) { described_class.as_hash('http://localhost', 'my-token', 100, 'my-previous-token') }
+
+      it 'generates the expected hash' do
+        expect(stream.to_h).to eq({ "url" => "http://localhost", "token" => "my-token", "offsetInMilliseconds" => 100, "expectedPreviousToken" => "my-previous-token" })
+      end
+    end
+
+    context 'without expected_previous_token' do
+      subject(:stream) { described_class.as_hash('http://localhost', 'my-token', 100) }
+
+      it 'generates the expected hash' do
+        expect(stream.to_h).to eq({ "url" => "http://localhost", "token" => "my-token", "offsetInMilliseconds" => 100 })
+      end
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/directives/audio_player/clear_queue_spec.rb
+++ b/spec/ralyxa/response_entities/directives/audio_player/clear_queue_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../../../spec_helper'
+
+RSpec.describe Ralyxa::ResponseEntities::Directives::AudioPlayer::ClearQueue do
+  describe 'constants' do
+    it 'has the expected constant values' do
+      expect(described_class::CLEAR_ENQUEUED).to eq('CLEAR_ENQUEUED')
+      expect(described_class::CLEAR_ALL).to eq('CLEAR_ALL')
+    end
+  end
+
+  describe '#to_h' do
+    it 'generates the expected hash' do
+      expect(described_class.new.to_h).to eq({ "type" => "AudioPlayer.ClearQueue", "clearBehavior" => "CLEAR_ENQUEUED" })
+    end
+  end
+
+  describe '.as_hash' do
+    context 'without a behaviour' do
+      it 'generates the expected hash' do
+        expect(described_class.as_hash).to eq({ "type" => "AudioPlayer.ClearQueue", "clearBehavior" => "CLEAR_ENQUEUED" })
+      end
+    end
+
+    context 'with a behaviour' do
+      it 'generates the expected hash' do
+        expect(described_class.as_hash('FOO')).to eq({ "type" => "AudioPlayer.ClearQueue", "clearBehavior" => "FOO" })
+      end
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/directives/audio_player/play_spec.rb
+++ b/spec/ralyxa/response_entities/directives/audio_player/play_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../../../../spec_helper'
+
+RSpec.describe Ralyxa::ResponseEntities::Directives::AudioPlayer::Play do
+  describe 'constants' do
+    it 'has the expected constant values' do
+      expect(described_class::REPLACE_ALL).to eq('REPLACE_ALL')
+      expect(described_class::ENQUEUE).to eq('ENQUEUE')
+      expect(described_class::CLEAR_ENQUEUE).to eq('CLEAR_ENQUEUE')
+    end
+  end
+
+  describe '#to_h' do
+    subject(:play) { described_class.new(Ralyxa::ResponseEntities::Directives::Audio::Stream.new('http://localhost', 'token')) }
+
+    it 'generates the expected hash' do
+      expect(play.to_h).to eq({ "type" => "AudioPlayer.Play", "playBehavior" => "REPLACE_ALL", "audioItem" => { "stream" => { "url" => "http://localhost", "token" => "token", "offsetInMilliseconds" => 0 } } })
+    end
+  end
+
+  describe '.as_hash' do
+    context 'without a behaviour' do
+      subject(:play) { described_class.new(Ralyxa::ResponseEntities::Directives::Audio::Stream.new('http://localhost', 'token')) }
+
+      it 'generates the expected hash' do
+        expect(play.to_h).to eq({ "type" => "AudioPlayer.Play", "playBehavior" => "REPLACE_ALL", "audioItem" => { "stream" => { "url" => "http://localhost", "token" => "token", "offsetInMilliseconds" => 0 } } })
+      end
+    end
+
+    context 'with a behaviour' do
+      subject(:play) { described_class.new(Ralyxa::ResponseEntities::Directives::Audio::Stream.new('http://localhost', 'token'), 'FOO') }
+
+      it 'generates the expected hash' do
+        expect(play.to_h).to eq({ "type" => "AudioPlayer.Play", "playBehavior" => "FOO", "audioItem" => { "stream" => { "url" => "http://localhost", "token" => "token", "offsetInMilliseconds" => 0 } } })
+      end
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/directives/audio_player/stop_spec.rb
+++ b/spec/ralyxa/response_entities/directives/audio_player/stop_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../../spec_helper'
+
+RSpec.describe Ralyxa::ResponseEntities::Directives::AudioPlayer::Stop do
+  describe '#to_h' do
+    it 'generates the expected hash' do
+      expect(described_class.new.to_h).to eq({ "type" => "AudioPlayer.Stop" })
+    end
+  end
+
+  describe '.as_hash' do
+    it 'generates the expected hash' do
+      expect(described_class.as_hash).to eq({ "type" => "AudioPlayer.Stop" })
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/directives/audio_player_spec.rb
+++ b/spec/ralyxa/response_entities/directives/audio_player_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../../../spec_helper'
+
+RSpec.describe Ralyxa::ResponseEntities::Directives::AudioPlayer do
+  let(:card) { Ralyxa::ResponseEntities::Card.as_hash('Hello World', 'This is a test', 'https://placehold.it/100', 'https://placehold.it/200') }
+
+  describe '.play' do
+    context 'with only the required attributes' do
+      it 'generates the expected json' do
+        expect(described_class.play('http://localhost', 'token')).to eq("{\"version\":\"1.0\",\"response\":{\"directives\":[{\"type\":\"AudioPlayer.Play\",\"playBehavior\":\"REPLACE_ALL\",\"audioItem\":{\"stream\":{\"url\":\"http://localhost\",\"token\":\"token\",\"offsetInMilliseconds\":0}}}],\"shouldEndSession\":false}}")
+      end
+    end
+
+    context 'with all attributes' do
+      it 'generates the expected json' do
+        expect(described_class.play('http://localhost', 'token', speech: 'My Radio', card: card, offset_in_milliseconds: 100, expected_previous_token: 'previous', behaviour: Ralyxa::ResponseEntities::Directives::AudioPlayer::Play::ENQUEUE)).to eq('{"version":"1.0","response":{"outputSpeech":{"type":"PlainText","text":"My Radio"},"card":{"type":"Standard","title":"Hello World","text":"This is a test","image":{"smallImageUrl":"https://placehold.it/100","largeImageUrl":"https://placehold.it/200"}},"directives":[{"type":"AudioPlayer.Play","playBehavior":"ENQUEUE","audioItem":{"stream":{"url":"http://localhost","token":"token","offsetInMilliseconds":100,"expectedPreviousToken":"previous"}}}],"shouldEndSession":false}}')
+      end
+    end
+  end
+
+  describe '.play_later' do
+    context 'with only the required attributes' do
+      it 'generates the expected json' do
+        expect(described_class.play_later('http://localhost', 'token')).to eq("{\"version\":\"1.0\",\"response\":{\"directives\":[{\"type\":\"AudioPlayer.Play\",\"playBehavior\":\"REPLACE_ENQUEUED\",\"audioItem\":{\"stream\":{\"url\":\"http://localhost\",\"token\":\"token\",\"offsetInMilliseconds\":0}}}],\"shouldEndSession\":false}}")
+      end
+    end
+
+    context 'with all attributes' do
+      it 'generates the expected json' do
+        expect(described_class.play_later('http://localhost', 'token', speech: 'My Radio', card: card, offset_in_milliseconds: 100, expected_previous_token: 'previous', behaviour: Ralyxa::ResponseEntities::Directives::AudioPlayer::Play::ENQUEUE)).to eq('{"version":"1.0","response":{"outputSpeech":{"type":"PlainText","text":"My Radio"},"card":{"type":"Standard","title":"Hello World","text":"This is a test","image":{"smallImageUrl":"https://placehold.it/100","largeImageUrl":"https://placehold.it/200"}},"directives":[{"type":"AudioPlayer.Play","playBehavior":"ENQUEUE","audioItem":{"stream":{"url":"http://localhost","token":"token","offsetInMilliseconds":100,"expectedPreviousToken":"previous"}}}],"shouldEndSession":false}}')
+      end
+    end
+  end
+
+  describe '.stop' do
+    context 'without speech' do
+      it 'generates the expected json' do
+        expect(described_class.stop).to eq("{\"version\":\"1.0\",\"response\":{\"directives\":[{\"type\":\"AudioPlayer.Stop\"}],\"shouldEndSession\":false}}")
+      end
+    end
+
+    context 'with speech' do
+      it 'with speech generates the expected json' do
+        expect(described_class.stop(speech: 'My Radio', card: card)).to eq('{"version":"1.0","response":{"outputSpeech":{"type":"PlainText","text":"My Radio"},"card":{"type":"Standard","title":"Hello World","text":"This is a test","image":{"smallImageUrl":"https://placehold.it/100","largeImageUrl":"https://placehold.it/200"}},"directives":[{"type":"AudioPlayer.Stop"}],"shouldEndSession":false}}')
+      end
+    end
+  end
+
+  describe '.clear_queue' do
+    context 'with only the default attributes' do
+      it 'generates the expected json' do
+        expect(described_class.clear_queue).to eq("{\"version\":\"1.0\",\"response\":{\"directives\":[{\"type\":\"AudioPlayer.ClearQueue\",\"clearBehavior\":\"CLEAR_ALL\"}],\"shouldEndSession\":false}}")
+      end
+    end
+
+    context 'with all attributes' do
+      it 'generates the expected json' do
+        expect(described_class.clear_queue(speech: 'My Radio', card: card, behaviour: Ralyxa::ResponseEntities::Directives::AudioPlayer::ClearQueue::CLEAR_ENQUEUED)).to eq('{"version":"1.0","response":{"outputSpeech":{"type":"PlainText","text":"My Radio"},"card":{"type":"Standard","title":"Hello World","text":"This is a test","image":{"smallImageUrl":"https://placehold.it/100","largeImageUrl":"https://placehold.it/200"}},"directives":[{"type":"AudioPlayer.ClearQueue","clearBehavior":"CLEAR_ENQUEUED"}],"shouldEndSession":false}}')
+      end
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/response_spec.rb
+++ b/spec/ralyxa/response_entities/response_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe Ralyxa::ResponseEntities::Response do
   subject(:response)  { described_class.as_hash(output_speech: output_speech) }
 
   describe '.as_hash' do
+    it 'returns an empty response if no options are provided' do
+      expected_response = {
+          version: "1.0",
+          response: {
+              shouldEndSession: false
+          }
+      }
+
+      custom_response = described_class.as_hash({})
+
+      expect(custom_response).to eq expected_response
+    end
+
     it 'returns a hash response with a custom string if provided' do
       expected_response = {
         version: "1.0",

--- a/spec/ralyxa_spec.rb
+++ b/spec/ralyxa_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Ralyxa do
       Ralyxa.validate_requests = 'foo'
       expect(Ralyxa.validate_requests).to eq('foo')
     end
+
+    it 'raises the expected method missing error for a genuinely missing method' do
+      expect{ Ralyxa.foo }.to raise_error(NoMethodError, 'undefined method `foo\' for Ralyxa:Module')
+    end
   end
 
   describe '#respond_to_missing' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter %r{^/spec/}
+end
+
 require 'ralyxa'
 require 'vcr'
 require 'timecop'
@@ -13,9 +18,12 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  Dir["./spec/support/**/*.rb"].each {|f| require f}
+
   config.before :each do
     Ralyxa.configure do |config|
       config.validate_requests = false
+      config.require_secure_urls = false
     end
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,15 @@
+shared_examples 'a configuration option' do |option|
+  it "allows #{option} to be configured" do
+    configuration  = described_class.new
+    boolean_method = "#{option.to_s}?".to_sym
+    setter_method  = "#{option.to_s}=".to_sym
+
+    expect(configuration.send(boolean_method)).to eq(true)
+
+    configuration.send(setter_method, false)
+    expect(configuration.send(boolean_method)).to eq(false)
+
+    configuration.send(setter_method, 'foo')
+    expect(configuration.send(boolean_method)).to eq('foo')
+  end
+end


### PR DESCRIPTION
This is an in progress branch to prevent duplication of work.
  
something like the following:
```ruby
audio_player = audio_player.play('https://example.com/file.mp3', 'my-token')
directives = [audio_player]
respond('My audio player', directives: directives)
```

----

Actually ends up being:
```ruby
audio_player.play('https://example.com/file.mp3', 'my-token', speech: 'My audio player')
```