### PR TITLE
Add reprompt text functionality

### DIFF
--- a/lib/ralyxa/response_builder.rb
+++ b/lib/ralyxa/response_builder.rb
@@ -3,18 +3,20 @@ require_relative './response_entities/response'
 
 module Ralyxa
   class ResponseBuilder
-    def initialize(response_class, output_speech_class, options)
+    def initialize(response_class, output_speech_class, reprompt_class, options)
       @response_class      = response_class
       @output_speech_class = output_speech_class
+      @reprompt_class      = reprompt_class
       @options             = options
     end
 
-    def self.build(options = {}, response_class = Ralyxa::ResponseEntities::Response, output_speech_class = Ralyxa::ResponseEntities::OutputSpeech)
-      new(response_class, output_speech_class, options).build
+    def self.build(options = {}, response_class = Ralyxa::ResponseEntities::Response, output_speech_class = Ralyxa::ResponseEntities::OutputSpeech, reprompt_class = Ralyxa::ResponseEntities::Reprompt)
+      new(response_class, output_speech_class, reprompt_class, options).build
     end
 
     def build
       merge_output_speech if response_text_exists?
+      merge_reprompt if reprompt_exists?
       merge_card if card_exists?
 
       @response_class.as_hash(@options).to_json
@@ -24,6 +26,10 @@ module Ralyxa
 
     def merge_output_speech
       @options.merge!(output_speech: output_speech)
+    end
+
+    def merge_reprompt
+      @options.merge!(reprompt: reprompt)
     end
 
     def merge_card
@@ -38,11 +44,22 @@ module Ralyxa
       @options[:response_text]
     end
 
+    def reprompt_exists?
+      @options[:reprompt]
+    end
+
     def output_speech
       output_speech_params = { speech: @options.delete(:response_text) }
       output_speech_params[:ssml] = @options.delete(:ssml) if @options[:ssml]
 
       @output_speech_class.as_hash(output_speech_params)
+    end
+
+    def reprompt
+      reprompt_params = { reprompt_speech: @options.delete(:reprompt) }
+      reprompt_params[:reprompt_ssml] = @options.delete(:reprompt_ssml) if @options[:reprompt_ssml]
+
+      @reprompt_class.as_hash(reprompt_params)
     end
   end
 end

--- a/lib/ralyxa/response_entities/reprompt.rb
+++ b/lib/ralyxa/response_entities/reprompt.rb
@@ -1,0 +1,20 @@
+module Ralyxa
+  module ResponseEntities
+    class Reprompt
+      def initialize(reprompt_speech, reprompt_ssml)
+        @reprompt_speech = reprompt_speech
+        @reprompt_ssml   = reprompt_ssml
+      end
+
+      def to_h
+        {}.tap do |reprompt|
+          reprompt[:outputSpeech] = Ralyxa::ResponseEntities::OutputSpeech.as_hash(speech: @reprompt_speech, ssml: @reprompt_ssml)
+        end
+      end
+
+      def self.as_hash(reprompt_speech: nil, reprompt_ssml: false)
+        new(reprompt_speech, reprompt_ssml).to_h
+      end
+    end
+  end
+end

--- a/lib/ralyxa/response_entities/response.rb
+++ b/lib/ralyxa/response_entities/response.rb
@@ -1,11 +1,13 @@
 require_relative './output_speech'
+require_relative './reprompt'
 require_relative './directives'
 
 module Ralyxa
   module ResponseEntities
     class Response
-      def initialize(output_speech, session_attributes, end_session, start_over, card, directives)
+      def initialize(output_speech, reprompt, session_attributes, end_session, start_over, card, directives)
         @output_speech      = output_speech
+        @reprompt           = reprompt
         @session_attributes = session_attributes
         @end_session        = end_session
         @start_over         = start_over
@@ -21,8 +23,8 @@ module Ralyxa
         end
       end
 
-      def self.as_hash(output_speech: false, session_attributes: {}, end_session: false, start_over: false, card: false, directives: false)
-        new(output_speech, session_attributes, end_session, start_over, card, directives).to_h
+      def self.as_hash(output_speech: false, reprompt: false, session_attributes: {}, end_session: false, start_over: false, card: false, directives: false)
+        new(output_speech, reprompt, session_attributes, end_session, start_over, card, directives).to_h
       end
 
       private
@@ -41,6 +43,7 @@ module Ralyxa
       def add_response(response)
         response[:response] = {}.tap do |response_object|
           response_object[:outputSpeech]     = @output_speech if @output_speech
+          response_object[:reprompt]         = @reprompt      if @reprompt
           response_object[:card]             = @card          if @card
           response_object[:directives]       = @directives    if @directives
           response_object[:shouldEndSession] = @end_session

--- a/spec/ralyxa/response_builder_spec.rb
+++ b/spec/ralyxa/response_builder_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Ralyxa::ResponseBuilder do
   let(:response_class)       { double(:"Ralyxa::Response", as_hash: {}) }
   let(:output_speech)        { double(:alexa_output_speech) }
   let(:output_speech_class)  { double(:"Ralyxa::OutputSpeech", as_hash: output_speech) }
+  let(:reprompt)             { double(:alexa_reprompt) }
+  let(:reprompt_class)       { double(:"Ralyxa::Reprompt", as_hash: reprompt) }
 
   describe '.build' do
     it 'constructs an OutputSpeech object using relevant options' do
@@ -41,6 +43,23 @@ RSpec.describe Ralyxa::ResponseBuilder do
         expect(response_class).to receive(:as_hash).with({})
 
         Ralyxa::ResponseBuilder.build({}, response_class, output_speech_class)
+      end
+    end
+
+    context 'with a reprompt object' do
+      let(:reprompt)      { "Please say that again." }
+      let(:response_text) { "Hello World" }
+
+      it 'constructs a reprompt object using relevant options' do
+        expect(reprompt_class).to receive(:as_hash).with(reprompt_speech: reprompt)
+
+        Ralyxa::ResponseBuilder.build({ response_text: response_text, reprompt: reprompt }, response_class, output_speech_class, reprompt_class)
+      end
+
+      it 'constructs a repromp object using SSML' do
+        expect(reprompt_class).to receive(:as_hash).with(reprompt_speech: reprompt, reprompt_ssml: true)
+
+        Ralyxa::ResponseBuilder.build({ response_text: response_text, reprompt: reprompt, reprompt_ssml: true }, response_class, output_speech_class, reprompt_class)
       end
     end
 

--- a/spec/ralyxa/response_entities/reprompt_spec.rb
+++ b/spec/ralyxa/response_entities/reprompt_spec.rb
@@ -1,0 +1,55 @@
+require 'ralyxa/response_entities/reprompt'
+
+RSpec.describe Ralyxa::ResponseEntities::Reprompt do
+  describe 'building a reprompt component of a response' do
+    it 'defaults to plain text and "Hello World"' do
+      expected_reprompt = {
+        outputSpeech: {
+          type: "PlainText",
+          text: "Hello World"
+        }
+      }
+
+      expect(Ralyxa::ResponseEntities::Reprompt.as_hash).to eq expected_reprompt
+    end
+
+    it 'outputs a custom string if given' do
+      expected_reprompt = {
+        outputSpeech: {
+          type: "PlainText",
+          text: "Custom Text"
+        }
+      }
+
+      expect(Ralyxa::ResponseEntities::Reprompt.as_hash(reprompt_speech: "Custom Text")).to eq expected_reprompt
+    end
+
+    it 'outputs SSML if given' do
+      expected_reprompt = {
+        outputSpeech: {
+          type: "SSML",
+          ssml: "<speak>Hello World</speak>"
+        }
+      }
+
+      expect(Ralyxa::ResponseEntities::Reprompt.as_hash(reprompt_speech: "<speak>Hello World</speak>", reprompt_ssml: true)).to eq expected_reprompt
+    end
+
+    it 'outputs default SSML if no string is given but SSML is required' do
+      expected_reprompt = {
+        outputSpeech: {
+          type: "SSML",
+          ssml: "<speak>Hello World</speak>"
+        }
+      }
+
+      expect(Ralyxa::ResponseEntities::Reprompt.as_hash(reprompt_ssml: true)).to eq expected_reprompt
+    end
+
+    it 'does not limits the speech' do
+      long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque interdum rutrum sodales. Nullam mattis fermentum libero, noon volutpat."
+
+      expect(Ralyxa::ResponseEntities::Reprompt.as_hash(reprompt_speech: long_string)[:outputSpeech][:text]).to eq long_string
+    end
+  end
+end

--- a/spec/ralyxa/response_entities/response_spec.rb
+++ b/spec/ralyxa/response_entities/response_spec.rb
@@ -36,6 +36,31 @@ RSpec.describe Ralyxa::ResponseEntities::Response do
       expect(custom_response).to eq expected_response
     end
 
+    it 'returns a hash response with a reprompt if provided' do
+      expected_response = {
+        version: "1.0",
+        response: {
+          outputSpeech: {
+            type: "PlainText",
+            text: "Custom String"
+          },
+          reprompt: {
+            outputSpeech: {
+              type: "PlainText",
+              text: "Please say that again."
+            },
+          },
+          shouldEndSession: false
+        }
+      }
+
+      output_speech = { type: "PlainText", text: "Custom String" }
+      reprompt = { outputSpeech: { type: "PlainText", text: "Please say that again." } }
+      custom_response = described_class.as_hash(output_speech: output_speech, reprompt: reprompt)
+
+      expect(custom_response).to eq expected_response
+    end
+
     it 'can use SSML if provided' do
       expected_response = {
         version: "1.0",
@@ -50,6 +75,30 @@ RSpec.describe Ralyxa::ResponseEntities::Response do
 
       output_speech = { type: "SSML", ssml: "<speak>Hello World</speak>" }
       ssml_response = described_class.as_hash(output_speech: output_speech)
+      expect(ssml_response).to eq expected_response
+    end
+
+    it 'can use SSML for reprompt if provided' do
+      expected_response = {
+        version: "1.0",
+        response: {
+          outputSpeech: {
+            type: "SSML",
+            ssml: "<speak>Hello World</speak>"
+          },
+          reprompt: {
+            outputSpeech: {
+              type: "SSML",
+              text: "<speak>Please say that again.</speak>"
+            },
+          },
+          shouldEndSession: false
+        }
+      }
+
+      output_speech = { type: "SSML", ssml: "<speak>Hello World</speak>" }
+      reprompt = { outputSpeech: { type: "SSML", text: "<speak>Please say that again.</speak>" } }
+      ssml_response = described_class.as_hash(output_speech: output_speech, reprompt: reprompt)
       expect(ssml_response).to eq expected_response
     end
 


### PR DESCRIPTION
Closes #11

**Changes**
- Added new `Reprompt` class which creates a new `OutputSpeech`  object and returns it as a hash.
- Added references for a newly created `Reprompt` class where needed.
- Added unit tests.

**Example**
`ask("Welcome to search", reprompt: "What are you looking for?")`

[![IAlexa reprompt test](http://img.youtube.com/vi/1ZfnfP090CI/0.jpg)](http://www.youtube.com/watch?v=1ZfnfP090CI "Alexa reprompt test")