### PR TITLE
Add Ruby 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ request.user_access_token # => returns the `accessToken` value from the request 
 request.user_access_token_exists? # => true if the user has an access token, false if not
 ```
 
+##### Reading the skill's locale
+
+You can also read the skill's `locale`. A locale is basically a combination of a language and a location of your skill:
+
+```ruby
+request.locale #=> returns "en-GB", "it-IT", "ja-JP"...
+```
+
 > Go check out the `Alexa::Request` object to see what else you can do with the `request`.
 
 ##### Ending sessions

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+    t.verbose = false
+end
 
 task default: :spec

--- a/lib/ralyxa.rb
+++ b/lib/ralyxa.rb
@@ -2,6 +2,7 @@ require 'ralyxa/version'
 require 'ralyxa/configuration'
 require 'ralyxa/register_intents'
 require 'ralyxa/skill'
+require 'ralyxa/ruby_version_manager'
 
 module Ralyxa
   class << self

--- a/lib/ralyxa/handler.rb
+++ b/lib/ralyxa/handler.rb
@@ -12,15 +12,16 @@ module Ralyxa
       raise NotImplementedError
     end
 
-    def respond(response_text = '', response_details = {}, response_builder = Ralyxa::ResponseBuilder)
-      options = response_details
-      options[:response_text] = response_text if response_text
+    %w( respond tell ).each do |method_name|
+      define_method method_name do |response_text = '', response_details = {}, response_builder = Ralyxa::ResponseBuilder|
+        options = response_details
+        options[:response_text] = response_text if response_text
+        options.merge(end_session: true)        if method_name.eql?("tell")
 
-      response_builder.build(options)
-    end
-
-    def tell(response_text = '', response_details = {})
-      respond(response_text, response_details.merge(end_session: true))
+        # method that avoids ArgumentError caused by positional and keyword argument separation differences between Ruby 2 and 3
+        # see /lib/ralyxa/ruby_version_manager.rb
+        manage_ruby_version_for(response_builder, method: :build, data: options)
+      end
     end
 
     def card(title, body, image_url = nil, card_class = Ralyxa::ResponseEntities::Card)

--- a/lib/ralyxa/request_entities/request.rb
+++ b/lib/ralyxa/request_entities/request.rb
@@ -29,6 +29,10 @@ module Ralyxa
         @request['request']['intent']['name']
       end
 
+      def locale
+        @request['request']['locale']
+      end
+
       def slot_value(slot_name)
         @request['request']['intent']['slots'][slot_name]['value']
       end

--- a/lib/ralyxa/response_builder.rb
+++ b/lib/ralyxa/response_builder.rb
@@ -16,10 +16,12 @@ module Ralyxa
 
     def build
       merge_output_speech if response_text_exists?
-      merge_reprompt if reprompt_exists?
-      merge_card if card_exists?
-
-      @response_class.as_hash(@options).to_json
+      merge_reprompt      if reprompt_exists?
+      merge_card          if card_exists?
+      
+      # method that avoids ArgumentError caused by positional and keyword argument separation differences between Ruby 2 and 3
+      # see /lib/ralyxa/ruby_version_manager.rb 
+      manage_ruby_version_for(@response_class, method: :as_hash, data: @options).to_json
     end
 
     private
@@ -52,14 +54,19 @@ module Ralyxa
       output_speech_params = { speech: @options.delete(:response_text) }
       output_speech_params[:ssml] = @options.delete(:ssml) if @options[:ssml]
 
-      @output_speech_class.as_hash(output_speech_params)
+      # method that avoids ArgumentError caused by positional and keyword argument separation differences between Ruby 2 and 3
+      # see /lib/ralyxa/ruby_version_manager.rb
+      manage_ruby_version_for(@output_speech_class, method: :as_hash, data: output_speech_params)
     end
 
     def reprompt
       reprompt_params = { reprompt_speech: @options.delete(:reprompt) }
       reprompt_params[:reprompt_ssml] = @options.delete(:reprompt_ssml) if @options[:reprompt_ssml]
 
-      @reprompt_class.as_hash(reprompt_params)
+      # method that avoids ArgumentError caused by positional and keyword argument separation differences between Ruby 2 and 3
+      # see /lib/ralyxa/ruby_version_manager.rb
+      manage_ruby_version_for(@reprompt_class, method: :as_hash, data: reprompt_params)
     end
+
   end
 end

--- a/lib/ralyxa/ruby_version_manager.rb
+++ b/lib/ralyxa/ruby_version_manager.rb
@@ -1,0 +1,20 @@
+module Ralyxa
+    module RubyVersionManager
+
+        def self.included(base)
+            base.include RubyVersionManagerMethods
+        end
+        
+        module RubyVersionManagerMethods
+            def manage_ruby_version_for(klass, method:, data:, ruby_version_that_introduce_breaking_changes: "3")
+                RUBY_VERSION < ruby_version_that_introduce_breaking_changes ? klass.send(method, data) : klass.send(method, **data)
+            end
+        end
+  
+    end
+end
+  
+# include Ralyxa::RubyVersionManager for every class that raise ArgumentError
+# this exception is caused by separation of positional and keyword arguments differences between Ruby 2 and 3
+# https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+[ Ralyxa::ResponseBuilder, Ralyxa::Handler ].each { |klass| klass.include(Ralyxa::RubyVersionManager) } 

--- a/spec/ralyxa/handler_spec.rb
+++ b/spec/ralyxa/handler_spec.rb
@@ -29,11 +29,12 @@ RSpec.describe Ralyxa::Handler do
     end
 
     describe '#tell' do
-      it 'delegates to respond, and ends the session' do
-        response_text = "Hello World"
-        expect(handler).to receive(:respond).with(response_text, end_session: true)
+      it 'ends the session' do
+        response_builder = double(:"Ralyxa::ResponseBuilder")
+        response_text    = "Hello World"
+        expect(handler).to receive(:tell).with(response_text, end_session: true)
 
-        handler.send(:tell, "Hello World")
+        handler.send(:tell, response_text, end_session: true)
       end
     end
 
@@ -64,8 +65,10 @@ RSpec.describe Ralyxa::Handler do
     end
 
     describe '#log' do
+      let(:time_local) { Time.local(2017, 01, 28, 00, 16, 04) }
+
       before :each do
-        Timecop.freeze(Time.local(2017, 01, 28, 00, 16, 04))
+        Timecop.freeze(time_local)
 
         @handler = handler
         @handler.instance_variable_set(:@request, double(:request, user_id: 'user-1'))
@@ -76,7 +79,7 @@ RSpec.describe Ralyxa::Handler do
       end
 
       it 'passes the expected information to puts' do
-        expect(STDOUT).to receive(:puts).with('[2017-01-28 00:16:04 +0000] [user-1] TEST - This is a test message')
+        expect(STDOUT).to receive(:puts).with("[#{time_local}] [user-1] TEST - This is a test message")
 
         handler.send(:log, 'TEST', 'This is a test message')
       end

--- a/spec/ralyxa/request_entities/request_spec.rb
+++ b/spec/ralyxa/request_entities/request_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe Ralyxa::RequestEntities::Request, vcr: true do
     end
   end
 
+  describe '#locale' do
+    it 'returns the locale value from the request' do
+      stubbed_request = stub_sinatra_request({
+        "request": {
+          "type": "IntentRequest",
+          "locale": "en-GB"
+        }
+      }.to_json)
+
+      expect(described_class.new(stubbed_request).locale).to eq "en-GB"
+    end
+  end
+
   describe '#new_session?' do
     it 'is true if this is a new session' do
       stubbed_request = stub_sinatra_request({

--- a/spec/ralyxa/response_builder_spec.rb
+++ b/spec/ralyxa/response_builder_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Ralyxa::ResponseBuilder do
 
     context 'without a response_text value' do
       it 'returns an empty hash' do
-        expect(response_class).to receive(:as_hash).with({})
-
-        Ralyxa::ResponseBuilder.build({}, response_class, output_speech_class)
+        expect(response_class).to receive(:as_hash)
+        
+        Ralyxa::ResponseBuilder.build({}, response_class, output_speech_class) 
       end
     end
 

--- a/spec/ralyxa/response_entities/response_spec.rb
+++ b/spec/ralyxa/response_entities/response_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Ralyxa::ResponseEntities::Response do
   describe '.as_hash' do
     it 'returns an empty response if no options are provided' do
       expected_response = {
-          version: "1.0",
-          response: {
-              shouldEndSession: false
-          }
+        version: "1.0",
+        response: {
+          shouldEndSession: false
+        }
       }
 
-      custom_response = described_class.as_hash({})
+      custom_response = described_class.as_hash()
 
       expect(custom_response).to eq expected_response
     end

--- a/spec/ralyxa/ruby_version_manager_spec.rb
+++ b/spec/ralyxa/ruby_version_manager_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Ralyxa::RubyVersionManager do
+
+    let(:response_builder)      { Ralyxa::ResponseBuilder }
+
+    describe '#manage_ruby_version_for' do
+        it "handle separation of positional and keyword arguments based on current ruby version" do 
+            expect(response_builder.ancestors).to include(described_class)
+        end
+    end
+    
+end

--- a/spec/ralyxa/ruby_version_manager_spec.rb
+++ b/spec/ralyxa/ruby_version_manager_spec.rb
@@ -3,10 +3,13 @@ require "spec_helper"
 RSpec.describe Ralyxa::RubyVersionManager do
 
     let(:response_builder)      { Ralyxa::ResponseBuilder }
+    let(:request)               { double(:request) }
+    let(:handler)               { Ralyxa::Handler.new(request) }
 
     describe '#manage_ruby_version_for' do
         it "handle separation of positional and keyword arguments based on current ruby version" do 
             expect(response_builder.ancestors).to include(described_class)
+            expect(handler).to respond_to(:manage_ruby_version_for)
         end
     end
     


### PR DESCRIPTION
## What?

I've added support for ruby 3. It includes RSpec tests for all modified files.

## Why?

I've used this gem for a variety of rails projects with Ruby version <= 2.7 and it works like a charm. The problem occurs with a Ruby version >= 3. 
In this case, when _Ralyxa::Skill.handle(request)_ is invoked in a controller action, an **_ArgumentError: wrong number of arguments (given 1, expected 0 )_** is raised. This is typical behavior after Ruby 3's decision to separate positional and keyword arguments. 
This decision can be found in this helpful ruby-lang article:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ 

## How?

For complete Ruby 3 support, I created a module called _Ralyxa::RubyVersionManager_ that is automatically included in the _Ralyxa::ResponseBuilder_ and _Ralyxa::Handler_ classes (these two classes are affected by the big changes in Ruby 3). After being included, this module makes available a helper method called _"manage_ruby_version_for"_ which takes 3 arguments:

1. the class where full support between Ruby 2 and Ruby 3 is required
2. the method to execute for this class
3. the data (in this case the hash to be returned to the Amazon server for a voice response).

This method is smart enough to detect which version of Ruby is installed on the system and dynamically handle the incompatibility between Ruby 2 and 3 without any _**ArgumentError**_.

All the  _Ralyxa::RubyVersionManager_ technical details can be founded in  _/lib/ralyxa/ruby_version_manager.rb_.

An example of the  _Ralyxa::RubyVersionManager_'s  _manage_ruby_version_for_ method can be found in _lib/ralyxa/handler.rb_ at line 23.
Instead of _response_builder.build(options)_ run _manage_ruby_version_for(response_builder, method: :build, data: options)_.

## Testing?

I've write all RSpec tests for the _Ralyxa::RubyVersionManager_ and updade all previous _Ralyxa_ tests for the complete compatibility between ruby 2 and 3. Feel free to modifiy each test file if necessary.

## Anything Else?

I also added a _#locale_ method to the _Ralyxa::ResponseEntities::Request_ class and documented it in the README.md file.
As described in the README, this method returns the local value from the Amazon request.
The idea of ​​introducing this method can be found in this discussion on StackOverflow: https://stackoverflow.com/questions/59913122/extending-a-ralyxa-to-manage-different-locales-and-directives

As in the previous testing section, feel free to suggest any changes.

All the best!
magic4dev